### PR TITLE
fix(database-activator): paramametrize sql query to avoid postgres error

### DIFF
--- a/src/Activator/DatabaseActivator.php
+++ b/src/Activator/DatabaseActivator.php
@@ -91,12 +91,12 @@ class DatabaseActivator implements FeatureActivatorInterface
         // $result contains the response from state (true / false) or false if no feature found
         $result = $this->getConnection()->executeQuery(
             sprintf(
-                'SELECT %s FROM %s WHERE %s = "%s"',
+                'SELECT %s FROM %s WHERE %s = :feature_name',
                 $this->options['db_column_state'],
                 $this->options['db_table'],
                 $this->options['db_column_feature'],
-                $name
-            )
+            ),
+            ['feature_name' => $name]
         )->fetchOne();
 
         return is_bool($result) ? $result : filter_var($result, FILTER_VALIDATE_BOOLEAN);


### PR DESCRIPTION
Hello,

Thanks for this lib, and its easy to use and adaptable features.

I have an issue using the database activator with postgresql: doctrine throws an Doctrine\DBAL\Exception\InvalidFieldNameException, saying the column "feature_name" does not exist when trying to access the state of a feature in the database. The issue is caused by using double quotes in the request, that is not valid for a string in postgresql.

I suggest and implemented switching to parametrized query, to let doctrine adapt the sql query to the type of database.

Could you review it and tell me if this could be merged and released ? I see no potential breaking change in this change