### PR TITLE
Allow the installation of Doctrine DBAL 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor
 composer.lock
 build/logs/*
 !build/logs/.gitkeep
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   "require": {
     "php": "^7.3||^8.0",
     "flagception/flagception": "^1.7",
-    "doctrine/dbal":  "^2.12",
+    "doctrine/dbal":  "^2.13.1 || ^3.3",
     "symfony/options-resolver": ">=2.7"
   },
   "require-dev": {

--- a/tests/Activator/DatabaseActivatorTest.php
+++ b/tests/Activator/DatabaseActivatorTest.php
@@ -88,11 +88,11 @@ class DatabaseActivatorTest extends TestCase
     public function testSetConnectByPdo()
     {
         $activator = new DatabaseActivator([
+            'driver' => 'pdo_mysql',
             'pdo' => $pdo = $this->createMock(PDO::class)
         ]);
 
         $pdo
-            ->expects(static::once())
             ->method('getAttribute')
             ->with(PDO::ATTR_DRIVER_NAME)
             ->willReturn('mysql');
@@ -173,7 +173,7 @@ class DatabaseActivatorTest extends TestCase
             $stateColumn => false
         ]);
 
-        $result = $connection->executeQuery("SELECT $featureColumn, $stateColumn FROM $tableName")->fetchAllAssociative();
+        $result = $connection->fetchAllAssociative("SELECT $featureColumn, $stateColumn FROM $tableName");
 
         static::assertEquals([
             [


### PR DESCRIPTION
Doctrine DBAL 2 is EOL: https://www.doctrine-project.org/2022/01/22/sunsetting-dbal-2.html

This PR allows to install DBAL 3 while maintaining compatibility with DBAL 2.